### PR TITLE
Force HWE kernel and xserver installation

### DIFF
--- a/ubuntu/16.04/custom/preseed.cfg
+++ b/ubuntu/16.04/custom/preseed.cfg
@@ -164,6 +164,7 @@ d-i partman-auto/expert_recipe string         \
 ### Base system installation
 d-i base-installer/install-recommends boolean true
 d-i base-installer/kernel/image string linux-generic
+d-i base-installer/kernel/override-image string linux-generic-hwe-16.04
 
 ### Apt setup
 d-i apt-setup/restricted boolean true
@@ -176,7 +177,7 @@ d-i apt-setup/security_path string /ubuntu
 
 ### Package selection
 tasksel tasksel/first multiselect lubuntu-desktop
-d-i pkgsel/include string openssh-server python
+d-i pkgsel/include string openssh-server python xserver-xorg-hwe-16.04
 d-i pkgsel/upgrade select full-upgrade
 d-i pkgsel/update-policy select unattended-upgrades
 


### PR DESCRIPTION
Uses "base-installer/kernel/override-image" to set HWE kernel image.
Appends to "pkgsel/include" to add xserver video drivers.
